### PR TITLE
Fix Simg2img

### DIFF
--- a/lpunpack.py
+++ b/lpunpack.py
@@ -643,19 +643,19 @@ class SparseImage:
                     if chunk_header.chunk_type == 0xCAC2:
                         data = self._read_data(chunk_data_size)
                         len_data = sector_size << 9
-                        out.write(struct.pack("B", 0) * len_data)
+                        out.truncate(out.tell() + len_data)
                         output_len += len(data)
                         sector_base += sector_size
                     else:
                         if chunk_header.chunk_type == 0xCAC3:
                             data = self._read_data(chunk_data_size)
                             len_data = sector_size << 9
-                            out.write(struct.pack("B", 0) * len_data)
+                            out.truncate(out.tell() + len_data)
                             output_len += len(data)
                             sector_base += sector_size
                         else:
                             len_data = sector_size << 9
-                            out.write(struct.pack("B", 0) * len_data)
+                            out.truncate(out.tell() + len_data)
                             sector_base += sector_size
                 chunks -= 1
         return unsparse_file


### PR DESCRIPTION
write b“\x00” is not a good way, and it caused some problem when extracting