### PR TITLE
Fix: Remove mixed @property/@classmethod decorator causing TypeError

### DIFF
--- a/lpunpack.py
+++ b/lpunpack.py
@@ -172,9 +172,14 @@ class SparseChunkHeader(object):
 class LpMetadataBase:
     _fmt = None
 
-    @classmethod
+    # Don't mix @property and @classmethod decorators
+    # This will cause unexpected behavior
     @property
     def size(cls) -> int:
+        return struct.calcsize(cls._fmt)
+    
+    @classmethod
+    def get_size(cls) -> int: 
         return struct.calcsize(cls._fmt)
 
 
@@ -735,11 +740,11 @@ class LpUnpack(object):
         offsets = metadata.get_offsets()
         for index, offset in enumerate(offsets):
             self._fd.seek(offset, io.SEEK_SET)
-            header = LpMetadataHeader(self._fd.read(cast(int, LpMetadataHeader.size)))
-            header.partitions = LpMetadataTableDescriptor(self._fd.read(cast(int, LpMetadataTableDescriptor.size)))
-            header.extents = LpMetadataTableDescriptor(self._fd.read(cast(int, LpMetadataTableDescriptor.size)))
-            header.groups = LpMetadataTableDescriptor(self._fd.read(cast(int, LpMetadataTableDescriptor.size)))
-            header.block_devices = LpMetadataTableDescriptor(self._fd.read(cast(int, LpMetadataTableDescriptor.size)))
+            header = LpMetadataHeader(self._fd.read(cast(int, LpMetadataHeader.get_size())))
+            header.partitions = LpMetadataTableDescriptor(self._fd.read(cast(int, LpMetadataTableDescriptor.get_size())))
+            header.extents = LpMetadataTableDescriptor(self._fd.read(cast(int, LpMetadataTableDescriptor.get_size())))
+            header.groups = LpMetadataTableDescriptor(self._fd.read(cast(int, LpMetadataTableDescriptor.get_size())))
+            header.block_devices = LpMetadataTableDescriptor(self._fd.read(cast(int, LpMetadataTableDescriptor.get_size())))
 
             if header.magic != LP_METADATA_HEADER_MAGIC:
                 check_index = index + 1


### PR DESCRIPTION
Fix "slice indices must be integers" error when running `lpunpack.py` on Python 3.13.2 (macOS Sonoma 14.5 Intel).
The issue occurs due to incorrect type returned by size property.
Error log:
```
Traceback (most recent call last):
  File "/usr/local/bin/lpunpack.py", line 945, in <module>
    main()
    ~~~~^^
  File "/usr/local/bin/lpunpack.py", line 938, in main
    LpUnpack(**vars(namespace)).unpack()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/bin/lpunpack.py", line 833, in unpack
    metadata = self._read_metadata()
  File "/usr/local/bin/lpunpack.py", line 759, in _read_metadata
    metadata = Metadata(geometry=self._read_primary_geometry())
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/bin/lpunpack.py", line 806, in _read_primary_geometry
    geometry = LpMetadataGeometry(self._fd.read(LP_METADATA_GEOMETRY_SIZE))
  File "/usr/local/bin/lpunpack.py", line 209, in __init__
    ) = struct.unpack(self._fmt, buffer[0:self.size])
                                 ~~~~~~^^^^^^^^^^^^^
TypeError: slice indices must be integers or None or have an __index__ method
```

The fix is simple - separate property access and class methods by using both `@property` `def size()` for instance access and `@classmethod ` `def get_size()` for class-level size calculation.

